### PR TITLE
User-assigned Managed Identity for VMs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_user_assigned_identity" "policy" {
   location            = azurerm_resource_group.rg.location
 }
 
-// For optional use in policy assignments. Better naming convention than the system generated name.
+// Managed Identity assigned to VMs with no permissions for AMA Agent deployment through Policy Initiative
 resource "azurerm_user_assigned_identity" "vm" {
   name                = "id-cdmonitoring-vm-prod-${local.region_short}-001"
   resource_group_name = azurerm_resource_group.rg.name

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,13 @@ resource "azurerm_user_assigned_identity" "policy" {
   location            = azurerm_resource_group.rg.location
 }
 
+// For optional use in policy assignments. Better naming convention than the system generated name.
+resource "azurerm_user_assigned_identity" "vm" {
+  name                = "id-cdmonitoring-vm-prod-${local.region_short}-001"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+}
+
 
 
 // RBAC role assignments


### PR DESCRIPTION
Added additional User-assigned Managed Identity for AMA deployment Policy, to be deployed along with other bootstrap managed identities.

This additional identity is required when setting up the AMA deployment initiative.