### PR TITLE
Change to Deployment Stack Owner

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_user_assigned_identity" "policy" {
 // RBAC role assignments
 
 resource "azurerm_role_assignment" "resource_group" {
-  for_each             = toset(var.rbac ? ["Azure Deployment Stack Contributor", "Monitoring Contributor", "Storage Blob Data Contributor"] : [])
+  for_each             = toset(var.rbac ? ["Azure Deployment Stack Owner", "Monitoring Contributor", "Storage Blob Data Contributor"] : [])
   scope                = azurerm_resource_group.rg.id
   role_definition_name = each.value
   principal_id         = azurerm_user_assigned_identity.github.principal_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "rbac_commands" {
   value = var.rbac ? null : <<-EOF
 
-  az role assignment create --assignee ${azurerm_user_assigned_identity.github.principal_id} --role "Azure Deployment Stack Contributor" \
+  az role assignment create --assignee ${azurerm_user_assigned_identity.github.principal_id} --role "Azure Deployment Stack Owner" \
     --scope ${azurerm_resource_group.rg.id}
 
   az role assignment create --assignee ${azurerm_user_assigned_identity.github.principal_id} --role "Monitoring Contributor" \


### PR DESCRIPTION
Straight role change to Azure Deployment Stack Owner to avoid new validation error. Fixes https://github.com/Cloud-Direct-Monitoring/cd-monitoring-bootstrap/issues/31.