### PR TITLE
fix: Correct GitHub Actions workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - "main"
+  push:
+    branches:
+      - "main"
 
 permissions:
   contents: write

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,8 +9,9 @@ permissions:
   contents: write
 
 jobs:
-  terraform:
+  terraform_validation:
     name: Terraform Validation
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,10 +30,6 @@ jobs:
     - name: Terraform Init 🏃
       id: init
       run: terraform init
-
-    - name: Terraform fmt 📔
-      id: fmt
-      run: terraform fmt
 
     - name: Create dummy files 📄
       run: |
@@ -60,6 +57,50 @@ jobs:
 
         echo "Dummy files have been removed from ${SECRETS_PATH}"
 
+    - name: Generate detailed job summary 📖
+      run: |
+        SUMMARY=$'
+        ## Terraform Initialization ⚙️
+
+        ${{ steps.init.outcome }}
+
+        ## Terraform Validation 🤖
+
+        Outcome: ${{ steps.validate.outcome }}
+
+        Outputs: ${{ steps.validate.outputs.stdout }}
+
+        * Pusher: @${{ github.actor }}
+        * Action: ${{ github.event_name }}
+        * Working Directory: ${{ github.workspace }}
+        * Workflow: ${{ github.workflow }}
+        '
+
+        echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+
+  documentation:
+    name: Terraform Documentation
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout 🔔
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+    - name: Install Terraform ⛰️
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+      with:
+        terraform_version: latest
+
+    - name: Terraform Init 🏃
+      id: init
+      run: terraform init
+
+    - name: Terraform fmt 📔
+      id: fmt
+      run: terraform fmt
+
     - name: Setup TFLint 🖌️
       uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4
       with:
@@ -76,6 +117,7 @@ jobs:
       run: tflint -f compact
 
     - name: Generate Terraform Docs 📜
+      id: tfdocs
       uses: terraform-docs/gh-actions@e47bfa196e79fa50987ef391be236d9d97b0c786 # v1.2.0
       with:
         find-dir: .
@@ -95,12 +137,6 @@ jobs:
 
         ${{ steps.fmt.outcome }}
 
-        ## Terraform Validation 🤖
-
-        Outcome: ${{ steps.validate.outcome }}
-
-        Outputs: ${{ steps.validate.outputs.stdout }}
-
         ## TFLint
 
         Standard Output:
@@ -112,6 +148,12 @@ jobs:
         ${{ steps.tflint.outputs.stderr }}
 
         Exitcode: ${{ steps.tflint.outputs.exitcode }}
+
+        ## Terraform Docs
+
+        Changed Files:
+
+        ${{ steps.tfdocs.outputs.num_changed }}
 
         * Pusher: @${{ github.actor }}
         * Action: ${{ github.event_name }}


### PR DESCRIPTION
This fix addresses the issue with the Terraform Docs step attempting to commit changes to the forked repository. The workflow is now split into 2. 

The `terraform_validation` job only runs on pull requests and specifically validates that any Terraform code changes are valid and functional. 

The `documentation` job only runs on merge to the `main` branch and lints, formats and pushes any documentation changes to the main branch. 

The fundamental difference is in the `actions/checkout` task which differs between the two jobs. 